### PR TITLE
Add archiveServer method to the ServerHeader

### DIFF
--- a/resources/assets/js/pages/server/components/ServerHeader.vue
+++ b/resources/assets/js/pages/server/components/ServerHeader.vue
@@ -48,6 +48,11 @@
             server() {
                 return this.$store.state.serversStore.server;
             }
+        },
+        methods: {
+            archiveServer: function (server_id) {
+                this.$store.dispatch('archiveServer', server_id);
+            }
         }
     }
 </script>


### PR DESCRIPTION
archiveServer was only a method in the ServerNav component, this commit adds the method to the component in which it's needed, fixing #219.