### PR TITLE
Pass no-dev flag to composer installs.

### DIFF
--- a/app/Services/DeploymentServices/PHP/PHP.php
+++ b/app/Services/DeploymentServices/PHP/PHP.php
@@ -18,7 +18,7 @@ class PHP
      */
     public function installPhpDependencies()
     {
-        return $this->remoteTaskService->run('cd '.$this->release.'; composer install --no-progress --no-interaction');
+        return $this->remoteTaskService->run('cd '.$this->release.'; composer install --no-dev --no-progress --no-interaction');
     }
 
     /**


### PR DESCRIPTION
- Should fix our issue with dusk being registered in prod.
- Should be there IMO anyways.