### PR TITLE
Fix landing page rendering in Firefox

### DIFF
--- a/resources/assets/sass/public/_layout.scss
+++ b/resources/assets/sass/public/_layout.scss
@@ -17,6 +17,16 @@ header {
   }
 }
 
+.moz {
+  width: 100%;
+  height: 100%;
+  -moz-transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
 #content {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -58,7 +58,7 @@
             </script>
         @endif
     </head>
-    <body>
+    <body class="moz">
         <header>
             <ul class="nav nav--left">
                 <li>


### PR DESCRIPTION
In Firefox, the landing page looks very cramped. This PR fixes that issue.