### PR TITLE
Fix `catch-all` Site Configuration

### DIFF
--- a/app/Services/Systems/Ubuntu/V_16_04/WebService.php
+++ b/app/Services/Systems/Ubuntu/V_16_04/WebService.php
@@ -90,7 +90,8 @@ curl "' . config('app.url_stats') . '/webhook/server/' . $this->server->encode()
         $this->remoteTaskService->writeToFile('/etc/nginx/sites-available/catch-all', '
 server {
     listen 80 default_server;
-    listen [::]:80 default_server;                                                                                                                                                              
+    listen [::]:80 default_server;
+    server_name _;
     root /opt/codepier/landing;
 }');
         $this->remoteTaskService->createSymLink(

--- a/app/Services/Systems/Ubuntu/V_18_04/WebService.php
+++ b/app/Services/Systems/Ubuntu/V_18_04/WebService.php
@@ -91,6 +91,7 @@ curl "' . config('app.url_stats') . '/webhook/server/' . $this->server->encode()
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
+    server_name _;
     root /opt/codepier/landing;
 }');
         $this->remoteTaskService->createSymLink(


### PR DESCRIPTION
This adds the `server_name` directive to the catchall configuration to avoid nginx configuration conflicts.